### PR TITLE
Fix blob type case

### DIFF
--- a/src/id3.clj
+++ b/src/id3.clj
@@ -77,7 +77,7 @@
 				:id3.frame.type/user-text (m/map-vals :id3.frame/content (m/index-by :id3.frame/description frames))
 				:id3.frame.type/user-url (m/map-vals :id3.frame/content (m/index-by :id3.frame/description frames))
 				:id3.frame.type/picture (mapv #(select-keys % [:id3.frame/picture-type :id3.frame/mime-type :id3.frame/bytes]) frames)
-				:id3/frame.type/blob (mapv :id3.frame/bytes frames))))))
+				:id3.frame.type/blob (mapv :id3.frame/bytes frames))))))
 
 (defn normal->full [version tag] {
 	::magic-number "ID3"


### PR DESCRIPTION
It looks like there is a typo in full->normal in the cases. The extra slash in the case "id3/frame.type/blob" results in this error when calling it with a tag of the blob type

> Execution error (IllegalArgumentException) at id3/full->normal$fn (id3.clj:77).
> No matching clause: :id3.frame.type/blob